### PR TITLE
Add project sorting by order key

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -24,11 +24,12 @@ module.exports = function (eleventyConfig) {
     return (
       collectionApi
         .getFilteredByGlob(["projects/[^_]*.md"])
-        // sort by year (descending), then title (ascending)
+        // sort by year (descending), then sort order (ascending), then title (ascending)
         .sort(
           (a, b) =>
-            b.data.year - a.data.year ||
-            a.data.title.localeCompare(b.data.title)
+            (b.data.year - a.data.year) ||
+            ((a.data.order || 0) - (b.data.order || 0)) ||
+            (a.data.title.localeCompare(b.data.title))
         )
     );
   });

--- a/projects/alternative-clocks.md
+++ b/projects/alternative-clocks.md
@@ -3,8 +3,9 @@ layout: project
 title: Alternative Clocks
 author: Saralee Sittigaroon
 advisor: Dan Taeyoung
-year: 2024
+year: 2023
 image: /img/P1010020.jpeg
+order: -2
 links:
   - text: Project Website
     url: https://saralees.cargo.site/30798627

--- a/projects/colocate.md
+++ b/projects/colocate.md
@@ -3,8 +3,9 @@ layout: project
 title: "Colocate: A Collective Area Network"
 author: George Verghese
 advisor: Violet Whitney
-year: 2022
+year: 2023
 image: /img/colocate_coverimage.png
+order: 1
 links:
     -
       text: Learn More

--- a/projects/unpredictable-atmosphere.md
+++ b/projects/unpredictable-atmosphere.md
@@ -2,9 +2,10 @@
 layout: project
 title: "Unpredictable Atmosphere"
 author: Lucia Rebolino
-year: 2024
+year: 2023
 advisor: Laura Kurgan
 image: /img/UA_cover.jpg
+order: -1
 links:
   - text: "Explore"
     url: https://luciarebolino.github.io/UA24GHZ/


### PR DESCRIPTION
This PR adds support for ordering projects by a new `order` key in the YAML frontmatter, e.g.:

```
layout: project
title: Example Project
author: Seth Thompson
year: 2023
order: 1
```

Projects are now sorted by year (descending), sort order (ascending), and then title (ascending). Projects without an order key default to 0.